### PR TITLE
Add param to enable the devel repos

### DIFF
--- a/manifests/devel.pp
+++ b/manifests/devel.pp
@@ -1,10 +1,18 @@
 # Devel repos.  This actually means rc previews, pre-release softare, etc
-class puppetlabs_yum::devel inherits puppetlabs_yum::params {
+class puppetlabs_yum::devel  (
+  $enable_devel = false
+) inherits puppetlabs_yum::params {
+
+  if $enable_devel {
+    $enabled = 1
+  } else {
+    $enabled = 0
+  }
 
   yumrepo { 'puppetlabs-devel':
     baseurl  => "http://yum.puppetlabs.com/${urlbit}/devel/${::architecture}",
     descr    => "Puppet Labs Devel ${ostype} ${::os_maj_version} - ${::architecture}",
-    enabled  => '0',
+    enabled  => "${enabled}",
     gpgcheck => '1',
     gpgkey   => 'file:///yum.puppetlabs.com/RPM-GPG-KEY-puppetlabs',
   }
@@ -12,7 +20,7 @@ class puppetlabs_yum::devel inherits puppetlabs_yum::params {
   yumrepo { 'puppetlabs-devel-source':
     baseurl  => "http://yum.puppetlabs.com/${urlbit}/devel/SRPMS",
     descr    => "Puppet Labs Devel ${ostype} ${::os_maj_version} - Source",
-    enabled  => '0',
+    enabled  => "${enabled}",
     gpgcheck => '1',
     gpgkey   => 'file:///yum.puppetlabs.com/RPM-GPG-KEY-puppetlabs',
   }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -10,12 +10,16 @@
 # Sample Usage:
 #  include puppetlabs
 #
-class puppetlabs_yum inherits puppetlabs_yum::params {
+class puppetlabs_yum (
+  $enable_devel = false
+) inherits puppetlabs_yum::params {
 
   if $::osfamily == 'RedHat' {
     include puppetlabs_yum::products
     include puppetlabs_yum::deps
-    include puppetlabs_yum::devel
+    class { "puppetlabs_yum::devel":
+      enable_devel   => $enable_devel,
+    }
 
     puppetlabs_yum::rpm_gpg_key{ 'RPM-GPG-KEY-puppetlabs':
       path => '/etc/pki/rpm-gpg/RPM-GPG-KEY-puppetlabs',


### PR DESCRIPTION
Previously the devel repos would be disabled. This commit allows a parameter to
be passed into the class that will be passed into the devel class which can be
used to enable the puppet devel repos. It defaults to false, so is backwards
compatible with previous module releases.
