### PR TITLE
Permit selection of YUM mirror

### DIFF
--- a/Modulefile
+++ b/Modulefile
@@ -1,5 +1,5 @@
 name    'stahnma-puppetlabs_yum'
-version '0.1.3'
+version '0.1.4'
 source 'http://github.com/stahnma/puppet-module-puppetlabs_yum'
 author 'stahnma'
 license 'Apache License, Version 2.0'

--- a/README.md
+++ b/README.md
@@ -17,8 +17,7 @@ Other repositories that will setup but disabled (as per the puppetlabs-release s
 
 ## New in 0.1.4
 
-Sites that mirror PuppetLabs' YUM repo locally can now point at
-that cache.
+Sites that mirror PuppetLabs YUM repo locally can now point at that cache.
 
 ## New in 0.1.2
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,11 @@ Other repositories that will setup but disabled (as per the puppetlabs-release s
    * puppetlabs-devel (pre-release software)
    * puppetlabs-source (source packages)
 
+## New in 0.1.4
+
+Sites that mirror PuppetLabs' YUM repo locally can now point at
+that cache.
+
 ## New in 0.1.2
 
 This module now noops if you have PE installed as not to put the system in a state of confusion.

--- a/README.md
+++ b/README.md
@@ -17,12 +17,7 @@ Other repositories that will setup but disabled (as per the puppetlabs-release s
 
 ## New in 0.1.4
 
-<<<<<<< HEAD
 Sites that mirror PuppetLabs YUM repo locally can now point at that cache.
-=======
-Sites that mirror PuppetLabs' YUM repo locally can now point at
-that cache.
->>>>>>> f0b4c7dc8f3a0a0009419a07b3f800a28d09cd79
 
 ## New in 0.1.2
 

--- a/lib/facter/pper_installed.rb
+++ b/lib/facter/pper_installed.rb
@@ -2,6 +2,7 @@
 # system.
 
 Facter.add(:pper_installed) do
+  confine :osfamily => 'RedHat'
   setcode do
     %x{rpm -q pe-puppet-enterprise-release &> /dev/null}
     if $? == 0

--- a/lib/facter/pper_installed.rb
+++ b/lib/facter/pper_installed.rb
@@ -2,7 +2,6 @@
 # system.
 
 Facter.add(:pper_installed) do
-  confine :osfamily => 'RedHat'
   setcode do
     %x{rpm -q pe-puppet-enterprise-release &> /dev/null}
     if $? == 0

--- a/lib/facter/pper_installed.rb
+++ b/lib/facter/pper_installed.rb
@@ -2,6 +2,8 @@
 # system.
 
 Facter.add(:pper_installed) do
+  confine :osfamily => 'RedHat'
+
   setcode do
     %x{rpm -q pe-puppet-enterprise-release &> /dev/null}
     if $? == 0

--- a/lib/facter/pper_installed.rb
+++ b/lib/facter/pper_installed.rb
@@ -3,7 +3,6 @@
 
 Facter.add(:pper_installed) do
   confine :osfamily => 'RedHat'
-
   setcode do
     %x{rpm -q pe-puppet-enterprise-release &> /dev/null}
     if $? == 0

--- a/manifests/deps.pp
+++ b/manifests/deps.pp
@@ -1,17 +1,20 @@
 # Deps are things puppet labs product need to pull in for dependency
 #  resolution.  Ideally you won't need EPEL or somet other repository with Puppet
 #  Labs Product + Deps.
-class puppetlabs_yum::deps inherits puppetlabs_yum::params {
+class puppetlabs_yum::deps (
+  $url_prefix,
+  $url_prefixsrc,
+) inherits puppetlabs_yum::params {
 
   yumrepo { 'puppetlabs-deps':
-    baseurl  => "http://yum.puppetlabs.com/${params::urlbit}/dependencies/${::architecture}",
+    baseurl  => "${url_prefix}${params::urlbit}/dependencies/${::architecture}",
     descr    => "Puppet Labs Dependencies ${params::ostype} ${::os_maj_version} - ${::architecture}",
     enabled  => '1',
     gpgcheck => '1',
     gpgkey   => 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-puppetlabs',
   }
   yumrepo { 'puppetlabs-deps-source':
-    baseurl  => "http://yum.puppetlabs.com/${params::urlbit}/dependencies/SRPMS",
+    baseurl  => "${url_prefixsrc}${params::urlbit}/dependencies/SRPMS",
     descr    => "Puppet Labs Source Dependencies ${params::ostype} ${::os_maj_version} - ${::architecture} - Source",
     enabled  => '0',
     gpgcheck => '1',

--- a/manifests/devel.pp
+++ b/manifests/devel.pp
@@ -1,6 +1,8 @@
 # Devel repos.  This actually means rc previews, pre-release softare, etc
 class puppetlabs_yum::devel  (
-  $enable_devel = false
+  $enable_devel = false,
+  $url_prefix,
+  $url_prefixsrc,
 ) inherits puppetlabs_yum::params {
 
   if $enable_devel {
@@ -10,7 +12,7 @@ class puppetlabs_yum::devel  (
   }
 
   yumrepo { 'puppetlabs-devel':
-    baseurl  => "http://yum.puppetlabs.com/${params::urlbit}/devel/${::architecture}",
+    baseurl  => "${url_prefix}${params::urlbit}/devel/${::architecture}",
     descr    => "Puppet Labs Devel ${params::ostype} ${::os_maj_version} - ${::architecture}",
     enabled  => $enabled,
     gpgcheck => '1',
@@ -18,7 +20,7 @@ class puppetlabs_yum::devel  (
   }
 
   yumrepo { 'puppetlabs-devel-source':
-    baseurl  => "http://yum.puppetlabs.com/${params::urlbit}/devel/SRPMS",
+    baseurl  => "${url_prefix}${params::urlbit}/devel/SRPMS",
     descr    => "Puppet Labs Devel ${params::ostype} ${::os_maj_version} - ${::architecture} - Source",
     enabled  => $enabled,
     gpgcheck => '1',

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -14,7 +14,7 @@ class puppetlabs_yum (
   $enable_devel = false
 ) inherits puppetlabs_yum::params {
 
-  if $::pper_installed == 'false' {
+  if $::pper_installed == 'false' or $::pper_installed == undef {
 
     if $::osfamily == 'RedHat' {
       include puppetlabs_yum::products

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -8,19 +8,33 @@
 #     Scientific, Oracle, Ascendos, et al)
 #
 # Sample Usage:
-#  include puppetlabs
+#  include puppetlabs_yum
 #
 class puppetlabs_yum (
-  $enable_devel = false
+  $enable_devel = false,
+  $urlprefix_products    = 'http://yum.puppetlabs.com/',
+  $urlprefix_productssrc = 'http://yum.puppetlabs.com/',
+  $urlprefix_deps        = 'http://yum.puppetlabs.com/',
+  $urlprefix_depssrc     = 'http://yum.puppetlabs.com/',
+  $urlprefix_devel       = 'http://yum.puppetlabs.com/',
+  $urlprefix_develsrc    = 'http://yum.puppetlabs.com/',
 ) inherits puppetlabs_yum::params {
 
   if $::pper_installed == 'false' or $::pper_installed == undef {
 
     if $::osfamily == 'RedHat' {
-      include puppetlabs_yum::products
-      include puppetlabs_yum::deps
+      class { 'puppetlabs_yum::products':
+        url_prefix    => $urlprefix_products,
+        url_prefixsrc => $urlprefix_productssrc,
+      }
+      class { 'puppetlabs_yum::deps':
+        url_prefix    => $urlprefix_deps,
+        url_prefixsrc => $urlprefix_depssrc,
+      }
       class { 'puppetlabs_yum::devel':
         enable_devel   => $enable_devel,
+        url_prefix    => $urlprefix_devel,
+        url_prefixsrc => $urlprefix_develsrc,
       }
 
       puppetlabs_yum::rpm_gpg_key{ 'RPM-GPG-KEY-puppetlabs':

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -20,7 +20,7 @@ class puppetlabs_yum (
   $urlprefix_develsrc    = 'http://yum.puppetlabs.com/',
 ) inherits puppetlabs_yum::params {
 
-  if $::pper_installed == 'false' or $::pper_installed == undef {
+  if $::pper_installed == undef or not str2bool($::pper_installed) {
 
     if $::osfamily == 'RedHat' {
       class { 'puppetlabs_yum::products':
@@ -32,7 +32,7 @@ class puppetlabs_yum (
         url_prefixsrc => $urlprefix_depssrc,
       }
       class { 'puppetlabs_yum::devel':
-        enable_devel   => $enable_devel,
+        enable_devel  => $enable_devel,
         url_prefix    => $urlprefix_devel,
         url_prefixsrc => $urlprefix_develsrc,
       }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -14,7 +14,7 @@ class puppetlabs_yum (
   $enable_devel = false
 ) inherits puppetlabs_yum::params {
 
-  if $::pper_installed == true {
+  if $::pper_installed == 'false' {
 
     if $::osfamily == 'RedHat' {
       include puppetlabs_yum::products

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -8,19 +8,34 @@
 #     Scientific, Oracle, Ascendos, et al)
 #
 # Sample Usage:
-#  include puppetlabs
+#  include puppetlabs_yum
 #
 class puppetlabs_yum (
-  $enable_devel = false
+  $enable_devel = false,
+  $override_pper_installed = false,
+  $urlprefix_products    = 'http://yum.puppetlabs.com/',
+  $urlprefix_productssrc = 'http://yum.puppetlabs.com/',
+  $urlprefix_deps        = 'http://yum.puppetlabs.com/',
+  $urlprefix_depssrc     = 'http://yum.puppetlabs.com/',
+  $urlprefix_devel       = 'http://yum.puppetlabs.com/',
+  $urlprefix_develsrc    = 'http://yum.puppetlabs.com/',
 ) inherits puppetlabs_yum::params {
 
-  if $::pper_installed == true {
+  if $override_pper_installed or $::pper_installed {
 
     if $::osfamily == 'RedHat' {
-      include puppetlabs_yum::products
-      include puppetlabs_yum::deps
+      class { 'puppetlabs_yum::products':
+        url_prefix    => $urlprefix_products,
+        url_prefixsrc => $urlprefix_productssrc,
+      }
+      class { 'puppetlabs_yum::deps':
+        url_prefix    => $urlprefix_deps,
+        url_prefixsrc => $urlprefix_depssrc,
+      }
       class { 'puppetlabs_yum::devel':
         enable_devel   => $enable_devel,
+        url_prefix    => $urlprefix_devel,
+        url_prefixsrc => $urlprefix_develsrc,
       }
 
       puppetlabs_yum::rpm_gpg_key{ 'RPM-GPG-KEY-puppetlabs':

--- a/manifests/products.pp
+++ b/manifests/products.pp
@@ -4,8 +4,6 @@ class puppetlabs_yum::products (
   $url_prefixsrc,
 ) inherits puppetlabs_yum::params {
 
-  #fail("YYYYYYY ${url_prefix}")
-
   yumrepo { 'puppetlabs-products':
     baseurl  => "${url_prefix}${params::urlbit}/products/${::architecture}",
     descr    => "Puppet Labs Products ${params::ostype} ${::os_maj_version} - ${::architecture}",

--- a/manifests/products.pp
+++ b/manifests/products.pp
@@ -1,8 +1,13 @@
 # Products include puppet, facter, mcollective, puppetdb, etc
-class puppetlabs_yum::products inherits puppetlabs_yum::params {
+class puppetlabs_yum::products (
+  $url_prefix,
+  $url_prefixsrc,
+) inherits puppetlabs_yum::params {
+
+  #fail("YYYYYYY ${url_prefix}")
 
   yumrepo { 'puppetlabs-products':
-    baseurl  => "http://yum.puppetlabs.com/${params::urlbit}/products/${::architecture}",
+    baseurl  => "${url_prefix}${params::urlbit}/products/${::architecture}",
     descr    => "Puppet Labs Products ${params::ostype} ${::os_maj_version} - ${::architecture}",
     enabled  => '1',
     gpgcheck => '1',
@@ -10,7 +15,7 @@ class puppetlabs_yum::products inherits puppetlabs_yum::params {
   }
 
   yumrepo { 'puppetlabs-products-source':
-    baseurl        => "http://yum.puppetlabs.com/${params::urlbit}/products/SRPMS",
+    baseurl        => "${url_prefixsrc}${params::urlbit}/products/SRPMS",
     descr          => "Puppet Labs Products ${params::ostype} ${::os_maj_version} - ${::architecture} - Source",
     enabled        => '0',
     failovermethod => 'priority',


### PR DESCRIPTION
Our site mirrors the PuppetLabs repos.  This pull request adds the ability for the caller of puppetlabs_yum to specify the first part of the URL, therefore giving us the ability to point at our local mirror instead of yum.puppetlabs.com.
