### PR TITLE
Fixing rpm_gpg_key check for existing key installed to work.

### DIFF
--- a/manifests/rpm_gpg_key.pp
+++ b/manifests/rpm_gpg_key.pp
@@ -4,7 +4,7 @@ define puppetlabs_yum::rpm_gpg_key($path) {
   exec {  "import-${name}":
     path      => '/bin:/usr/bin:/sbin:/usr/sbin',
     command   => "rpm --import ${path}",
-    unless    => "rpm -q gpg-pubkey-`$(echo $(gpg --throw-keyids < ${path}) | cut --characters=11-18 | tr [A-Z] [a-z])`",
+    unless    => "rpm -q gpg-pubkey-`echo $(gpg --throw-keyids < ${path}) | cut --characters=11-18 | tr [A-Z] [a-z]`",
     require   => File[$path],
     logoutput => 'on_failure',
   }


### PR DESCRIPTION
 Otherwise it keeps on re-importing the key every puppet agent run (at least on AmazonLinux).
